### PR TITLE
chore: env-driven multi-instance Artemis (ARTEMIS_HOST_N / ARTEMIS_PASSWORD / ARTEMIS_INSTANCES)

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,43 +7,43 @@ quarkus.http.port=8701
 
 
 # Instances: 1..8
-com.mobiera.ms.mno.quarkus.artemis.instances=1
+com.mobiera.ms.mno.quarkus.artemis.instances=${ARTEMIS_INSTANCES:1}
 com.mobiera.ms.mno.quarkus.artemis.brokername=0.0.0.0
 
 com.mobiera.artemis.producer.poolsize=16
 
 
-quarkus.artemis."a0".url=tcp://artemis:61616
+quarkus.artemis."a0".url=tcp://${ARTEMIS_HOST_0:${ARTEMIS_HOST:localhost}}:61616
 quarkus.artemis."a0".username=quarkus
-quarkus.artemis."a0".password=quarkus
+quarkus.artemis."a0".password=${ARTEMIS_PASSWORD:quarkus}
 
-quarkus.artemis."a1".url=tcp://artemis:61616
+quarkus.artemis."a1".url=tcp://${ARTEMIS_HOST_1:${ARTEMIS_HOST:localhost}}:61616
 quarkus.artemis."a1".username=quarkus
-quarkus.artemis."a1".password=quarkus
+quarkus.artemis."a1".password=${ARTEMIS_PASSWORD:quarkus}
 
-quarkus.artemis."a2".url=tcp://artemis:61616
+quarkus.artemis."a2".url=tcp://${ARTEMIS_HOST_2:${ARTEMIS_HOST:localhost}}:61616
 quarkus.artemis."a2".username=quarkus
-quarkus.artemis."a2".password=quarkus
+quarkus.artemis."a2".password=${ARTEMIS_PASSWORD:quarkus}
 
-quarkus.artemis."a3".url=tcp://artemis:61616
+quarkus.artemis."a3".url=tcp://${ARTEMIS_HOST_3:${ARTEMIS_HOST:localhost}}:61616
 quarkus.artemis."a3".username=quarkus
-quarkus.artemis."a3".password=quarkus
+quarkus.artemis."a3".password=${ARTEMIS_PASSWORD:quarkus}
 
-quarkus.artemis."a4".url=tcp://artemis:61616
+quarkus.artemis."a4".url=tcp://${ARTEMIS_HOST_4:${ARTEMIS_HOST:localhost}}:61616
 quarkus.artemis."a4".username=quarkus
-quarkus.artemis."a4".password=quarkus
+quarkus.artemis."a4".password=${ARTEMIS_PASSWORD:quarkus}
 
-quarkus.artemis."a5".url=tcp://artemis:61616
+quarkus.artemis."a5".url=tcp://${ARTEMIS_HOST_5:${ARTEMIS_HOST:localhost}}:61616
 quarkus.artemis."a5".username=quarkus
-quarkus.artemis."a5".password=quarkus
+quarkus.artemis."a5".password=${ARTEMIS_PASSWORD:quarkus}
 
-quarkus.artemis."a6".url=tcp://artemis:61616
+quarkus.artemis."a6".url=tcp://${ARTEMIS_HOST_6:${ARTEMIS_HOST:localhost}}:61616
 quarkus.artemis."a6".username=quarkus
-quarkus.artemis."a6".password=quarkus
+quarkus.artemis."a6".password=${ARTEMIS_PASSWORD:quarkus}
 
-quarkus.artemis."a7".url=tcp://artemis:61616
+quarkus.artemis."a7".url=tcp://${ARTEMIS_HOST_7:${ARTEMIS_HOST:localhost}}:61616
 quarkus.artemis."a7".username=quarkus
-quarkus.artemis."a7".password=quarkus
+quarkus.artemis."a7".password=${ARTEMIS_PASSWORD:quarkus}
 
 
 


### PR DESCRIPTION
## What

Wire the Artemis connection factories `a0..a7` and the broker instance count to environment variables, replacing the hardcoded `tcp://artemis:61616` host and the literal `quarkus` password:

- `quarkus.artemis."aN".url` → `tcp://${ARTEMIS_HOST_N:${ARTEMIS_HOST:localhost}}:61616`
- `quarkus.artemis."aN".password` → `${ARTEMIS_PASSWORD:quarkus}`
- `com.mobiera.ms.mno.quarkus.artemis.instances` → `${ARTEMIS_INSTANCES:1}`

## Why

The per-operation Kubernetes deployment (`aircast-operation-deployment-template`) no longer runs a single `artemis` Service — brokers are separate servers `artemis-0..artemis-<N-1>`. The chart injects `ARTEMIS_HOST`, `ARTEMIS_HOST_0..N-1`, `ARTEMIS_INSTANCES` (and `ARTEMIS_PASSWORD` as a secret). This brings `service-log` to parity with the `mno-adapters-*` family so it can connect to the multi-instance broker.

Local `mvn quarkus:dev` is unchanged: defaults fall back to `localhost` / `quarkus` / `1` instance.

## Context

Part of adding `service-log` to the operation deployment as **N stateless replicas sharing one standalone Postgres** (Artemis `service-log-queue` consumer).