### PR TITLE
build: upgrade to Quarkus 3.35.3 / Java 25 (match pm-model)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,15 +28,16 @@
       <url>https://github.com/mobiera/service-log-api/tree/main</url>
    </scm>
   <properties>
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
-    <maven.compiler.release>11</maven.compiler.release>
+    <compiler-plugin.version>3.13.0</compiler-plugin.version>
+    <failsafe.useModulePath>false</failsafe.useModulePath>
+    <maven.compiler.release>25</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.6.8</quarkus.platform.version>
+    <quarkus.platform.version>3.35.3</quarkus.platform.version>
     <skipITs>true</skipITs>
-    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
+    <surefire-plugin.version>3.5.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -80,10 +81,6 @@
       <artifactId>quarkus-smallrye-openapi</artifactId>
     </dependency>
     <dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-rest-client</artifactId>
-</dependency>
-    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-hibernate-orm</artifactId>
     </dependency>
@@ -98,12 +95,12 @@
    <dependency>
       <groupId>io.quarkiverse.artemis</groupId>
       <artifactId>quarkus-artemis-core</artifactId>
-      <version>3.1.3</version>
+      <version>3.10.2</version>
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.artemis</groupId>
       <artifactId>quarkus-artemis-jms</artifactId>
-      <version>3.1.3</version>
+      <version>3.10.2</version>
     </dependency>
      <dependency>
       <groupId>org.graalvm.sdk</groupId>


### PR DESCRIPTION
## What

Bring `service-log` to the same platform as `mno-adapters-pm-model`:

| | before | after |
|---|---|---|
| `quarkus.platform.version` | 3.6.8 | **3.35.3** |
| `maven.compiler.release` | 11 | **25** |
| `compiler-plugin.version` | 3.8.1 | **3.13.0** |
| `surefire-plugin.version` | 3.0.0-M7 | **3.5.2** |
| Artemis extension | 3.1.3 | **3.10.2** |

Also added `failsafe.useModulePath=false` for parity with pm-model/stats.

## Required side-change to make it build

- **Removed unused `quarkus-rest-client`** (the reactive "Quarkus REST" client). The project uses the classic `quarkus-resteasy` server; in 3.35 keeping the reactive client triggers *"Mixing Quarkus REST and RESTEasy Classic server parts is not supported"*. No source references it, so it's dropped rather than swapped.

## Verification

`mvn -B -ntp -DskipTests clean package` → **BUILD SUCCESS** locally on JDK 25.0.3 + Maven 3.9.16 (`target/quarkus-app/quarkus-run.jar` produced). Container-image build/push step is unrelated (registry auth).

## Context

Prepares `service-log` for the per-operation Helm deployment (`aircast-operation-deployment-template`). Companion to the Artemis multi-instance PR (#5).