### PR TITLE
fix(docker): run on Java 25 base (fixes UnsupportedClassVersionError)

### DIFF
--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.18
+FROM registry.access.redhat.com/ubi9/openjdk-25:1.24
 
 ENV LANGUAGE='en_US:en'
 


### PR DESCRIPTION
## Problem

Same Java-version mismatch as `stats`: the app compiles to Java 25 (`maven.compiler.release=25`, built with `temurin-25`) but `src/main/docker/Dockerfile.jvm` ran on `ubi8/openjdk-17`. Java 17 can't load class file version 69.0 (Java 25), so the container would crash at startup with `UnsupportedClassVersionError`.

## Fix

Bump the runtime base to `registry.access.redhat.com/ubi9/openjdk-25:1.24` (same as `pm-model`).