### PR TITLE
feat: notify Discord on release and add manual resend trigger

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,15 @@ name: release-please
 on:
   push:
     branches: [main]
+  # Manual trigger to (re)send a Discord release notification for an existing
+  # tag, e.g. to backfill a release published before the webhook secret was set.
+  # Only the discord-notify-manual job runs for this event.
+  workflow_dispatch:
+    inputs:
+      notify_tag:
+        description: "Release tag to (re)announce on Discord, e.g. v5.7.0"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -11,6 +20,7 @@ permissions:
 
 jobs:
   release-please:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -77,3 +87,30 @@ jobs:
             -t "${IMAGE}:${TAG_NAME}" .
           docker push "${IMAGE}:main"
           docker push "${IMAGE}:${TAG_NAME}"
+
+  # release-please creates the GitHub Release with the default GITHUB_TOKEN, so
+  # the `release: published` event does NOT trigger downstream workflows. We
+  # therefore call the Discord notification reusable workflow directly here,
+  # gated on the `release_created` output, instead of via a `release` trigger.
+  # The webhook secret is passed explicitly (not `secrets: inherit`) because the
+  # reusable workflow lives in another org (2060-io) and inherited secrets are
+  # not reliably forwarded across the org boundary.
+  discord-notify:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    uses: 2060-io/organization/.github/workflows/discord-release-notify-call.yml@main
+    with:
+      tag_name: ${{ needs.release-please.outputs.tag_name }}
+    secrets:
+      DISCORD_UPDATES_WEBHOOK_URL: ${{ secrets.DISCORD_UPDATES_WEBHOOK_URL }}
+
+  # Manual (re)send of the Discord notification for an existing tag, triggered
+  # via workflow_dispatch. Independent of release-please so it can announce a
+  # tag that was already released.
+  discord-notify-manual:
+    if: github.event_name == 'workflow_dispatch'
+    uses: 2060-io/organization/.github/workflows/discord-release-notify-call.yml@main
+    with:
+      tag_name: ${{ inputs.notify_tag }}
+    secrets:
+      DISCORD_UPDATES_WEBHOOK_URL: ${{ secrets.DISCORD_UPDATES_WEBHOOK_URL }}


### PR DESCRIPTION
## What

Adds Discord release notifications to the `release-please` workflow, matching `mno-adapters-pm-model`:

- **`discord-notify`** — on a real release (gated on `release_created`), calls the shared reusable workflow `2060-io/organization/.github/workflows/discord-release-notify-call.yml@main` to post release notes to Discord.
- **`discord-notify-manual`** — `workflow_dispatch` with a `notify_tag` input to (re)send a notification for an existing tag.
- `release-please` job gated to `push` events so manual runs only notify.

## Why this shape

The release is created with the default `GITHUB_TOKEN`, so `release: published` does not trigger downstream workflows — we call the notifier directly. The webhook secret is passed **explicitly** (not `secrets: inherit`) because the reusable workflow is in another org (`2060-io`) and inherited secrets aren't reliably forwarded across the org boundary.

## Follow-up

Add an **Actions** secret `DISCORD_UPDATES_WEBHOOK_URL` (repo or `mobiera` org). Without it the job runs but posts nothing (no failure).